### PR TITLE
Update Babel and use Amazon SDK

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": [ "es2015" ],
+  "plugins": [ "add-module-exports" ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ht-sqs-transport",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "An Amazon SQS Hudson Taylor transport",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ht-sqs-transport",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "An Amazon SQS Hudson Taylor transport",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/hudson-taylor/ht-sqs-transport.git"
+    "url": "https://github.com/chobomuffin/ht-sqs-transport.git"
   },
   "keywords": [
     "ht",
@@ -23,9 +23,9 @@
   "author": "Adam Brady <adam@boxxen.org>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/hudson-taylor/ht-sqs-transport/issues"
+    "url": "https://github.com/chobomuffin/ht-sqs-transport/issues"
   },
-  "homepage": "https://github.com/hudson-taylor/ht-sqs-transport",
+  "homepage": "https://github.com/chobomuffin/ht-sqs-transport",
   "devDependencies": {
     "async": "^0.9.0",
     "babel-cli": "^6.18.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/chobomuffin/ht-sqs-transport.git"
+    "url": "https://github.com/hudson-taylor/ht-sqs-transport.git"
   },
   "keywords": [
     "ht",
@@ -23,9 +23,9 @@
   "author": "Adam Brady <adam@boxxen.org>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/chobomuffin/ht-sqs-transport/issues"
+    "url": "https://github.com/hudson-taylor/ht-sqs-transport/issues"
   },
-  "homepage": "https://github.com/chobomuffin/ht-sqs-transport",
+  "homepage": "https://github.com/hudson-taylor/ht-sqs-transport",
   "devDependencies": {
     "async": "^0.9.0",
     "aws-sdk-mock": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ht-sqs-transport",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "An Amazon SQS Hudson Taylor transport",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/chobomuffin/ht-sqs-transport",
   "devDependencies": {
     "async": "^0.9.0",
+    "aws-sdk-mock": "^1.6.1",
     "babel-cli": "^6.18.0",
     "babel-plugin-add-module-exports": "^0.1.2",
     "babel-preset-es2015": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.6.12",
+    "sqs-consumer": "^3.3.0",
     "uid2": "0.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "ht-schema": "0.0.11",
     "hudson-taylor": "^2.4.1",
     "istanbul": "^0.3.7",
-    "mocha": "^2.2.0"
+    "mocha": "^2.2.0",
+    "proxyquire": "^1.7.10"
   },
   "dependencies": {
     "aws-sdk": "^2.6.12",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An Amazon SQS Hudson Taylor transport",
   "main": "lib/index.js",
   "scripts": {
-    "build": "node ./node_modules/babel/bin/babel src -d lib && node ./node_modules/babel/bin/babel test-src -d test",
+    "build": "babel src -d lib && babel test-src -d test",
     "test": "npm run build && mocha -R spec --bail --check-leaks test/",
     "prepublish": "npm run build",
     "coverage": "npm run build && ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -- --ui bdd --recursive -R spec -t 5000",
@@ -28,7 +28,10 @@
   "homepage": "https://github.com/hudson-taylor/ht-sqs-transport",
   "devDependencies": {
     "async": "^0.9.0",
-    "babel": "^4.7.1",
+    "babel-cli": "^6.18.0",
+    "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-preset-es2015": "^6.5.0",
+    "babel-register": "^6.5.2",
     "coveralls": "^2.11.2",
     "ht-schema": "0.0.11",
     "hudson-taylor": "^2.4.1",
@@ -36,7 +39,7 @@
     "mocha": "^2.2.0"
   },
   "dependencies": {
-    "sqs": "^1.2.0",
+    "aws-sdk": "^2.6.12",
     "uid2": "0.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ht-sqs-transport",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "An Amazon SQS Hudson Taylor transport",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ht-sqs-transport",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "An Amazon SQS Hudson Taylor transport",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ht-sqs-transport",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "An Amazon SQS Hudson Taylor transport",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ht-sqs-transport",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "An Amazon SQS Hudson Taylor transport",
   "main": "lib/index.js",
   "scripts": {

--- a/src/findOrCreateQueue.js
+++ b/src/findOrCreateQueue.js
@@ -15,10 +15,49 @@ function findQueue(sqs, queueName, callback) {
   });
 }
 
-function createQueue(sqs, queueName, callback) {
+
+
+function getQueueARN(sqs, queueUrl, callback) {
   var params = {
+    AttributeNames: [
+      'QueueArn'
+    ],
+    QueueUrl: queueUrl
+ };
+
+ sqs.getQueueAttributes(params, function(err, data) {
+   if (err) {
+     return callback(err);
+   }
+
+   return callback(null, data.Attributes.QueueArn)
+ });
+}
+
+function createDeadLetterQueue(sqs, queueName, callback) {
+  createQueue(sqs, queueName + "-dead-queue", function (err, queueUrl) {
+    if (err) {
+      return callback(err);
+    }
+
+    getQueueARN(sqs, queueUrl, function (err, queueArn) {
+      if (err) {
+        return callback(err);
+      }
+
+      callback(null, queueArn)
+    });
+  });
+}
+
+function createQueueWithRedrivePolicy(sqs, queueName, deadQueueArn, maxReceiveCount, callback) {
+  var params = {
+    Attributes: {
+      'RedrivePolicy': '{"deadLetterTargetArn":"' + deadQueueArn + '","maxReceiveCount":"' + maxReceiveCount + '"}'
+    },
     QueueName: queueName
-  };
+  }
+
   sqs.createQueue(params, function(err, data) {
     if (err) {
       return callback(err)
@@ -28,7 +67,21 @@ function createQueue(sqs, queueName, callback) {
   });
 }
 
-function findOrCreateQueue(sqs, queueName, callback) {
+function createQueue(sqs, queueName, callback) {
+  var params = {
+    QueueName: queueName
+  }
+
+  sqs.createQueue(params, function(err, data) {
+    if (err) {
+      return callback(err)
+    }
+
+    return callback(null, data.QueueUrl)
+  });
+}
+
+function findOrCreateQueue(sqs, queueName, maxReceiveCount, callback) {
   findQueue(sqs, queueName, function (err, queueUrl) {
     if (err) {
       return callback(err)
@@ -38,7 +91,17 @@ function findOrCreateQueue(sqs, queueName, callback) {
       return callback(null, queueUrl)
     }
 
-    createQueue(sqs, queueName, callback)
+    if (maxReceiveCount) {
+      createDeadLetterQueue(sqs, queueName, function (err, queueArn) {
+        if (err) {
+          return callback(err);
+        }
+
+        return createQueueWithRedrivePolicy(sqs, queueName, queueArn, maxReceiveCount, callback);
+      });
+    } else {
+      return createQueue(sqs, queueName, callback);
+    }
   })
 }
 

--- a/src/findOrCreateQueue.js
+++ b/src/findOrCreateQueue.js
@@ -1,0 +1,45 @@
+function findQueue(sqs, queueName, callback) {
+  var params = {
+    QueueNamePrefix: queueName
+  };
+  sqs.listQueues(params, function(err, data) {
+    if (err) {
+      return callback(err)
+    }
+
+    if (data.QueueUrls && data.QueueUrls.length > 0) {
+      callback(null, data.QueueUrls[0])
+    } else {
+      callback()
+    }
+  });
+}
+
+function createQueue(sqs, queueName, callback) {
+  var params = {
+    QueueName: queueName
+  };
+  sqs.createQueue(params, function(err, data) {
+    if (err) {
+      return callback(err)
+    }
+
+    return callback(null, data.QueueUrl)
+  });
+}
+
+function findOrCreateQueue(sqs, queueName, callback) {
+  findQueue(sqs, queueName, function (err, queueUrl) {
+    if (err) {
+      return callback(err)
+    }
+
+    if (queueUrl) {
+      return callback(null, queueUrl)
+    }
+
+    createQueue(sqs, queueName, callback)
+  })
+}
+
+export default findOrCreateQueue;

--- a/src/findOrCreateQueue.js
+++ b/src/findOrCreateQueue.js
@@ -35,7 +35,7 @@ function getQueueARN(sqs, queueUrl, callback) {
 }
 
 function createDeadLetterQueue(sqs, queueName, callback) {
-  createQueue(sqs, queueName + "-dead-queue", function (err, queueUrl) {
+  createQueue(sqs, queueName + "-dead", function (err, queueUrl) {
     if (err) {
       return callback(err);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ function SQSTransportServer(config, sqs) {
     let that = this;
     findOrCreateQueue(sqs, config.queueName, function(err, queueUrl) {
       consumer = SqsConsumer.create({
+        sqs: sqs,
         queueUrl: queueUrl,
         handleMessage: function (message, done) {
           let response = JSON.parse(message.Body)

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ function SQSTransportServer(config, sqs) {
 
   _SQSTransportServer.prototype.listen = function(done) {
     let that = this;
-    findOrCreateQueue(sqs, config.queueName, function(err, queueUrl) {
+    findOrCreateQueue(sqs, config.queueName, config.maxReceiveCount, function(err, queueUrl) {
       consumer = SqsConsumer.create({
         sqs: sqs,
         queueUrl: queueUrl,
@@ -48,7 +48,7 @@ function SQSTransportClient(config, queue) {
   };
 
   _SQSTransportClient.prototype.connect = function(done) {
-    findOrCreateQueue(queue, config.queueName, function (err, queueUrl) {
+    findOrCreateQueue(queue, config.queueName, config.maxReceiveCount, function (err, queueUrl) {
       config.queueUrl = queueUrl;
       done(err)
     });

--- a/src/index.js
+++ b/src/index.js
@@ -82,6 +82,11 @@ function SQSTransportClient(config, queue) {
 
 function SQSTransport(config) {
   AWS.config.update({region: config.region});
+
+  if (config.accessKeyId && config.secretAccessKey) {
+    AWS.config.update({accessKeyId: config.accessKeyId, secretAccessKey: config.secretAccessKey});
+  }
+
   let queue = new AWS.SQS();
 
   this.Server = SQSTransportServer(config, queue);

--- a/src/index.js
+++ b/src/index.js
@@ -11,12 +11,14 @@ function SQSTransportServer(config, sqs) {
   };
 
   _SQSTransportServer.prototype.listen = function(done) {
+    let that = this;
     findOrCreateQueue(sqs, config.queueName, function(err, queueUrl) {
       consumer = SqsConsumer.create({
         queueUrl: queueUrl,
         handleMessage: function (message, done) {
-          console.log(message)
-          done();
+          let response = JSON.parse(message.Body)
+          let { id, name, data } = response
+          that.fn(name, data, done)
         }
       });
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ function SQSTransportServer(config, sqs) {
       consumer = SqsConsumer.create({
         sqs: sqs,
         queueUrl: queueUrl,
+        visibilityTimeout: config.visibilityTimeout,
         handleMessage: function (message, done) {
           let response = JSON.parse(message.Body)
           let { id, name, data } = response

--- a/src/index.js
+++ b/src/index.js
@@ -84,8 +84,8 @@ function SQSTransportClient(config, queue) {
       QueueUrl: config.queueUrl
     };
 
-    queue.sendMessage(params, function(err, data) {
-        return callback(err, data)
+    queue.sendMessage(params, function(err, response) {
+      return callback(err, data)
     });
   };
 

--- a/test-src/index.js
+++ b/test-src/index.js
@@ -19,7 +19,7 @@ describe("Hudson-Taylor SQS Transport", function() {
 
       transport = new SQSTransport({
         region: 'ap-southeast-2',
-        queueUrl: 'https://sqs.ap-southeast-2.amazonaws.com/ID/NAME',
+        queueName: 'ht-queue-test-1234',
       });
 
       assert.equal(transport instanceof SQSTransport, true);
@@ -57,14 +57,14 @@ describe("Hudson-Taylor SQS Transport", function() {
       assert.equal(client instanceof transport.Client, true);
     });
 
-    it("should provide required functions", function(done) {
-
-      async.series([
-        client.connect,
-        client.disconnect
-      ], done);
-
-    });
+    // it("should provide required functions", function(done) {
+    //
+    //   async.series([
+    //     client.connect,
+    //     client.disconnect
+    //   ], done);
+    //
+    // });
 
   });
 
@@ -78,7 +78,7 @@ describe("Hudson-Taylor SQS Transport", function() {
 
       var transport = new SQSTransport({
         region: 'ap-southeast-2',
-        queueUrl: 'https://sqs.ap-southeast-2.amazonaws.com/ID/NAME',
+        queueName: 'ht-queue-test-xyz'
       });
 
       var service = new ht.Service(transport);
@@ -86,17 +86,18 @@ describe("Hudson-Taylor SQS Transport", function() {
         s: transport
       });
 
+      client.connect(function() {
+        client.call("s", "echo", str, function(err, response) {
+          assert.ifError(err);
+          assert.equal(response, str);
+          done();
+        });
+      });
+
       service.on("echo", s.String(), function(data, callback) {
         assert.equal({}, data)
         callback(null, data)
       });
-
-      client.call("s", "echo", str, function(err, response) {
-        assert.ifError(err);
-        assert.equal(response, str);
-        done();
-      });
-
     });
 
   });

--- a/test-src/index.js
+++ b/test-src/index.js
@@ -13,19 +13,14 @@ describe("Hudson-Taylor SQS Transport", function() {
 
   let transport;
 
-  before(function() {
-
-    [ "ACCESS_KEY_ID", "SECRET_ACCESS_KEY", "REGION" ].forEach(function(required) {
-      if(!process.env[required]) throw new Error("Environment variable " + required + " is required for running the tests.");
-    });
-
-  });
-
   describe("Transport", function() {
 
     it("should create transport instance", function() {
 
-      transport = new SQSTransport();
+      transport = new SQSTransport({
+        region: 'ap-southeast-2',
+        queueUrl: 'https://sqs.ap-southeast-2.amazonaws.com/ID/NAME',
+      });
 
       assert.equal(transport instanceof SQSTransport, true);
 
@@ -82,7 +77,8 @@ describe("Hudson-Taylor SQS Transport", function() {
       var str = "hello world!";
 
       var transport = new SQSTransport({
-        queueName: "ht-sqs-transport-test-queue"
+        region: 'ap-southeast-2',
+        queueUrl: 'https://sqs.ap-southeast-2.amazonaws.com/ID/NAME',
       });
 
       var service = new ht.Service(transport);
@@ -90,7 +86,10 @@ describe("Hudson-Taylor SQS Transport", function() {
         s: transport
       });
 
-      service.on("echo", s.String(), (data, callback) => callback(null, data));
+      service.on("echo", s.String(), function(data, callback) {
+        assert.equal({}, data)
+        callback(null, data)
+      });
 
       client.call("s", "echo", str, function(err, response) {
         assert.ifError(err);

--- a/test-src/index.js
+++ b/test-src/index.js
@@ -86,7 +86,7 @@ describe("Hudson-Taylor SQS Transport", function() {
       });
 
       it("should find a queue" , function (done) {
-        findOrCreateQueue(sqs, 'myQueue', function (err, queueUrl) {
+        findOrCreateQueue(sqs, 'myQueue', null, function (err, queueUrl) {
           assert.equal(queueUrl, 'my-queue-url');
           done();
         });
@@ -105,16 +105,28 @@ describe("Hudson-Taylor SQS Transport", function() {
           callback(null, { QueueUrl: 'my-created-queue-url' });
         }
 
+        function getQueueAttributes(params, callback) {
+          callback(null, { Attributes: { QueueArn: 'my-queue-arn' } });
+        }
+
         sqs = function() {
           return {
             listQueues: listQueues,
-            createQueue: createQueue
+            createQueue: createQueue,
+            getQueueAttributes: getQueueAttributes
           }
         }();
       });
 
-      it("should create a non existing queue", function (done) {
-        findOrCreateQueue(sqs, 'myQueue', function (err, queueUrl) {
+      it("should create a queue", function (done) {
+        findOrCreateQueue(sqs, 'myQueue', null, function (err, queueUrl) {
+          assert.equal(queueUrl, 'my-created-queue-url');
+          done();
+        });
+      });
+
+      it("should create a dead letter queue", function (done) {
+        findOrCreateQueue(sqs, 'myQueue', 100, function (err, queueUrl) {
           assert.equal(queueUrl, 'my-created-queue-url');
           done();
         });


### PR DESCRIPTION
The key things that have changed;
- Babel version
- Now using the Amazon SDK
- Configuration that you pass into the Transport

This PR currently requires a full queue URL. However we could just query the list of queues by name and just supply a name like the original one. 
